### PR TITLE
Add Airthings consumer API integration

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -18,6 +18,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "512761e0bb2578dd7380c6baaa0f4ce03e84f95e960231d1dec8bf4d7d6e2627"
 
 [[package]]
+name = "android_system_properties"
+version = "0.1.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "819e7219dbd41043ac279b19830f2efc897156490d7fd6ea916720117ee66311"
+dependencies = [
+ "libc",
+]
+
+[[package]]
 name = "async-trait"
 version = "0.1.83"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -27,6 +36,12 @@ dependencies = [
  "quote",
  "syn",
 ]
+
+[[package]]
+name = "atomic-waker"
+version = "1.1.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1505bd5d3d116872e7271a6d4e16d81d0c8570876c8de68093a09ac269d8aac0"
 
 [[package]]
 name = "autocfg"
@@ -101,8 +116,14 @@ dependencies = [
  "miniz_oxide",
  "object",
  "rustc-demangle",
- "windows-targets",
+ "windows-targets 0.52.6",
 ]
+
+[[package]]
+name = "base64"
+version = "0.22.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "72b3254f16251a8381aa12e40e3c4d2f0199f8c6508fbecb9d91f575e0fbb8c6"
 
 [[package]]
 name = "bitflags"
@@ -111,10 +132,26 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b048fb63fd8b5923fc5aa7b340d8e156aec7ec02f0c78fa8a6ddc2613f6f71de"
 
 [[package]]
+name = "bumpalo"
+version = "3.19.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "46c5e41b57b8bba42a04676d81cb89e9ee8e859a1a66f80a5a72e1cb76b34d43"
+
+[[package]]
 name = "bytes"
 version = "1.9.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "325918d6fe32f23b19878fe4b34794ae41fc19ddbe53b10571a4874d44ffd39b"
+
+[[package]]
+name = "cc"
+version = "1.2.47"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cd405d82c84ff7f35739f175f67d8b9fb7687a0e84ccdc78bd3568839827cf07"
+dependencies = [
+ "find-msvc-tools",
+ "shlex",
+]
 
 [[package]]
 name = "cfg-if"
@@ -123,10 +160,103 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "baf1de4339761588bc0619e3cbc0120ee582ebb74b53b4efbf79117bd2da40fd"
 
 [[package]]
+name = "chrono"
+version = "0.4.42"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "145052bdd345b87320e369255277e3fb5152762ad123a901ef5c262dd38fe8d2"
+dependencies = [
+ "iana-time-zone",
+ "js-sys",
+ "num-traits",
+ "serde",
+ "wasm-bindgen",
+ "windows-link 0.2.1",
+]
+
+[[package]]
+name = "core-foundation"
+version = "0.9.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "91e195e091a93c46f7102ec7818a2aa394e1e1771c3ab4825963fa03e45afb8f"
+dependencies = [
+ "core-foundation-sys",
+ "libc",
+]
+
+[[package]]
+name = "core-foundation-sys"
+version = "0.8.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "773648b94d0e5d620f64f280777445740e61fe701025087ec8b57f45c791888b"
+
+[[package]]
+name = "displaydoc"
+version = "0.2.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "97369cbbc041bc366949bc74d34658d6cda5621039731c6310521892a3a20ae0"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
+name = "encoding_rs"
+version = "0.8.35"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "75030f3c4f45dafd7586dd6780965a8c7e8e285a5ecb86713e63a79c5b2766f3"
+dependencies = [
+ "cfg-if",
+]
+
+[[package]]
+name = "equivalent"
+version = "1.0.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "877a4ace8713b0bcf2a4e7eec82529c029f1d0619886d18145fea96c3ffe5c0f"
+
+[[package]]
+name = "errno"
+version = "0.3.14"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "39cab71617ae0d63f51a36d69f866391735b51691dbda63cf6f96d042b63efeb"
+dependencies = [
+ "libc",
+ "windows-sys 0.52.0",
+]
+
+[[package]]
+name = "fastrand"
+version = "2.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "37909eebbb50d72f9059c3b6d82c0463f2ff062c9e95845c43a6c9c0355411be"
+
+[[package]]
+name = "find-msvc-tools"
+version = "0.1.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3a3076410a55c90011c298b04d0cfa770b00fa04e1e3c97d3f6c9de105a03844"
+
+[[package]]
 name = "fnv"
 version = "1.0.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3f9eec918d3f24069decb9af1554cad7c880e2da24a9afd88aca000531ab82c1"
+
+[[package]]
+name = "foreign-types"
+version = "0.3.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f6f339eb8adc052cd2ca78910fda869aefa38d22d5cb648e6485e4d3fc06f3b1"
+dependencies = [
+ "foreign-types-shared",
+]
+
+[[package]]
+name = "foreign-types-shared"
+version = "0.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "00b0228411908ca8685dba7fc2cdd70ec9990a6e753e89b6ac91a84c40fbaf4b"
 
 [[package]]
 name = "form_urlencoded"
@@ -153,6 +283,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "05f29059c0c2090612e8d742178b0580d2dc940c837851ad723096f87af6663e"
 
 [[package]]
+name = "futures-sink"
+version = "0.3.31"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e575fab7d1e0dcb8d0c7bcf9a63ee213816ab51902e6d244a95819acacf1d4f7"
+
+[[package]]
 name = "futures-task"
 version = "0.3.31"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -171,10 +307,58 @@ dependencies = [
 ]
 
 [[package]]
+name = "getrandom"
+version = "0.2.16"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "335ff9f135e4384c8150d6f27c6daed433577f86b4750418338c01a1a2528592"
+dependencies = [
+ "cfg-if",
+ "libc",
+ "wasi",
+]
+
+[[package]]
+name = "getrandom"
+version = "0.3.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "899def5c37c4fd7b2664648c28120ecec138e4d395b459e5ca34f9cce2dd77fd"
+dependencies = [
+ "cfg-if",
+ "libc",
+ "r-efi",
+ "wasip2",
+]
+
+[[package]]
 name = "gimli"
 version = "0.31.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "07e28edb80900c19c28f1072f2e8aeca7fa06b23cd4169cefe1af5aa3260783f"
+
+[[package]]
+name = "h2"
+version = "0.4.12"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f3c0b69cfcb4e1b9f1bf2f53f95f766e4661169728ec61cd3fe5a0166f2d1386"
+dependencies = [
+ "atomic-waker",
+ "bytes",
+ "fnv",
+ "futures-core",
+ "futures-sink",
+ "http",
+ "indexmap",
+ "slab",
+ "tokio",
+ "tokio-util",
+ "tracing",
+]
+
+[[package]]
+name = "hashbrown"
+version = "0.16.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "841d1cc9bed7f9236f321df977030373f4a4163ae1a7dbfe1a51a2c1a51d9100"
 
 [[package]]
 name = "http"
@@ -231,6 +415,7 @@ dependencies = [
  "bytes",
  "futures-channel",
  "futures-util",
+ "h2",
  "http",
  "http-body",
  "httparse",
@@ -239,6 +424,39 @@ dependencies = [
  "pin-project-lite",
  "smallvec",
  "tokio",
+ "want",
+]
+
+[[package]]
+name = "hyper-rustls"
+version = "0.27.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e3c93eb611681b207e1fe55d5a71ecf91572ec8a6705cdb6857f7d8d5242cf58"
+dependencies = [
+ "http",
+ "hyper",
+ "hyper-util",
+ "rustls",
+ "rustls-pki-types",
+ "tokio",
+ "tokio-rustls",
+ "tower-service",
+]
+
+[[package]]
+name = "hyper-tls"
+version = "0.6.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "70206fc6890eaca9fde8a0bf71caa2ddfc9fe045ac9e5c70df101a7dbde866e0"
+dependencies = [
+ "bytes",
+ "http-body-util",
+ "hyper",
+ "hyper-util",
+ "native-tls",
+ "tokio",
+ "tokio-native-tls",
+ "tower-service",
 ]
 
 [[package]]
@@ -248,20 +466,175 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "df2dcfbe0677734ab2f3ffa7fa7bfd4706bfdc1ef393f2ee30184aed67e631b4"
 dependencies = [
  "bytes",
+ "futures-channel",
  "futures-util",
  "http",
  "http-body",
  "hyper",
  "pin-project-lite",
+ "socket2",
  "tokio",
  "tower-service",
+ "tracing",
 ]
+
+[[package]]
+name = "iana-time-zone"
+version = "0.1.64"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "33e57f83510bb73707521ebaffa789ec8caf86f9657cad665b092b581d40e9fb"
+dependencies = [
+ "android_system_properties",
+ "core-foundation-sys",
+ "iana-time-zone-haiku",
+ "js-sys",
+ "log",
+ "wasm-bindgen",
+ "windows-core",
+]
+
+[[package]]
+name = "iana-time-zone-haiku"
+version = "0.1.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f31827a206f56af32e590ba56d5d2d085f558508192593743f16b2306495269f"
+dependencies = [
+ "cc",
+]
+
+[[package]]
+name = "icu_collections"
+version = "2.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4c6b649701667bbe825c3b7e6388cb521c23d88644678e83c0c4d0a621a34b43"
+dependencies = [
+ "displaydoc",
+ "potential_utf",
+ "yoke",
+ "zerofrom",
+ "zerovec",
+]
+
+[[package]]
+name = "icu_locale_core"
+version = "2.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "edba7861004dd3714265b4db54a3c390e880ab658fec5f7db895fae2046b5bb6"
+dependencies = [
+ "displaydoc",
+ "litemap",
+ "tinystr",
+ "writeable",
+ "zerovec",
+]
+
+[[package]]
+name = "icu_normalizer"
+version = "2.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5f6c8828b67bf8908d82127b2054ea1b4427ff0230ee9141c54251934ab1b599"
+dependencies = [
+ "icu_collections",
+ "icu_normalizer_data",
+ "icu_properties",
+ "icu_provider",
+ "smallvec",
+ "zerovec",
+]
+
+[[package]]
+name = "icu_normalizer_data"
+version = "2.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7aedcccd01fc5fe81e6b489c15b247b8b0690feb23304303a9e560f37efc560a"
+
+[[package]]
+name = "icu_properties"
+version = "2.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e93fcd3157766c0c8da2f8cff6ce651a31f0810eaa1c51ec363ef790bbb5fb99"
+dependencies = [
+ "icu_collections",
+ "icu_locale_core",
+ "icu_properties_data",
+ "icu_provider",
+ "zerotrie",
+ "zerovec",
+]
+
+[[package]]
+name = "icu_properties_data"
+version = "2.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "02845b3647bb045f1100ecd6480ff52f34c35f82d9880e029d329c21d1054899"
+
+[[package]]
+name = "icu_provider"
+version = "2.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "85962cf0ce02e1e0a629cc34e7ca3e373ce20dda4c4d7294bbd0bf1fdb59e614"
+dependencies = [
+ "displaydoc",
+ "icu_locale_core",
+ "writeable",
+ "yoke",
+ "zerofrom",
+ "zerotrie",
+ "zerovec",
+]
+
+[[package]]
+name = "idna"
+version = "1.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3b0875f23caa03898994f6ddc501886a45c7d3d62d04d2d90788d47be1b1e4de"
+dependencies = [
+ "idna_adapter",
+ "smallvec",
+ "utf8_iter",
+]
+
+[[package]]
+name = "idna_adapter"
+version = "1.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3acae9609540aa318d1bc588455225fb2085b9ed0c4f6bd0d9d5bcd86f1a0344"
+dependencies = [
+ "icu_normalizer",
+ "icu_properties",
+]
+
+[[package]]
+name = "indexmap"
+version = "2.12.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0ad4bb2b565bca0645f4d68c5c9af97fba094e9791da685bf83cb5f3ce74acf2"
+dependencies = [
+ "equivalent",
+ "hashbrown",
+]
+
+[[package]]
+name = "ipnet"
+version = "2.11.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "469fb0b9cefa57e3ef31275ee7cacb78f2fdca44e4765491884a2b119d4eb130"
 
 [[package]]
 name = "itoa"
 version = "1.0.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d75a2a4b1b190afb6f5425f10f6a8f959d2ea0b9c2b1d79553551850539e4674"
+
+[[package]]
+name = "js-sys"
+version = "0.3.82"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b011eec8cc36da2aab2d5cff675ec18454fad408585853910a202391cf9f8e65"
+dependencies = [
+ "once_cell",
+ "wasm-bindgen",
+]
 
 [[package]]
 name = "lazy_static"
@@ -274,6 +647,18 @@ name = "libc"
 version = "0.2.169"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b5aba8db14291edd000dfcc4d620c7ebfb122c613afb886ca8803fa4e128a20a"
+
+[[package]]
+name = "linux-raw-sys"
+version = "0.9.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cd945864f07fe9f5371a27ad7b52a172b4b499999f1d97574c9fa68373937e12"
+
+[[package]]
+name = "litemap"
+version = "0.8.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6373607a59f0be73a39b6fe456b8192fcc3585f602af20751600e974dd455e77"
 
 [[package]]
 name = "lock_api"
@@ -326,7 +711,33 @@ checksum = "2886843bf800fba2e3377cff24abf6379b4c4d5c6681eaf9ea5b0d15090450bd"
 dependencies = [
  "libc",
  "wasi",
- "windows-sys",
+ "windows-sys 0.52.0",
+]
+
+[[package]]
+name = "native-tls"
+version = "0.2.14"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "87de3442987e9dbec73158d5c715e7ad9072fda936bb03d19d7fa10e00520f0e"
+dependencies = [
+ "libc",
+ "log",
+ "openssl",
+ "openssl-probe",
+ "openssl-sys",
+ "schannel",
+ "security-framework",
+ "security-framework-sys",
+ "tempfile",
+]
+
+[[package]]
+name = "num-traits"
+version = "0.2.19"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "071dfc062690e90b734c0b2273ce72ad0ffa95f0c74596bc250dcfd960262841"
+dependencies = [
+ "autocfg",
 ]
 
 [[package]]
@@ -343,6 +754,50 @@ name = "once_cell"
 version = "1.20.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1261fe7e33c73b354eab43b1273a57c8f967d0391e80353e51f764ac02cf6775"
+
+[[package]]
+name = "openssl"
+version = "0.10.75"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "08838db121398ad17ab8531ce9de97b244589089e290a384c900cb9ff7434328"
+dependencies = [
+ "bitflags",
+ "cfg-if",
+ "foreign-types",
+ "libc",
+ "once_cell",
+ "openssl-macros",
+ "openssl-sys",
+]
+
+[[package]]
+name = "openssl-macros"
+version = "0.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a948666b637a0f465e8564c73e89d4dde00d72d4d473cc972f390fc3dcee7d9c"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
+name = "openssl-probe"
+version = "0.1.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d05e27ee213611ffe7d6348b942e8f942b37114c00cc03cec254295a4a17852e"
+
+[[package]]
+name = "openssl-sys"
+version = "0.9.111"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "82cab2d520aa75e3c58898289429321eb788c3106963d0dc886ec7a5f4adc321"
+dependencies = [
+ "cc",
+ "libc",
+ "pkg-config",
+ "vcpkg",
+]
 
 [[package]]
 name = "parking_lot"
@@ -364,7 +819,7 @@ dependencies = [
  "libc",
  "redox_syscall",
  "smallvec",
- "windows-targets",
+ "windows-targets 0.52.6",
 ]
 
 [[package]]
@@ -384,6 +839,21 @@ name = "pin-utils"
 version = "0.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8b870d8c151b6f2fb93e84a13146138f05d02ed11c7e7c54f8826aaaf7c9f184"
+
+[[package]]
+name = "pkg-config"
+version = "0.3.32"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7edddbd0b52d732b21ad9a5fab5c704c14cd949e5e9a1ec5929a24fded1b904c"
+
+[[package]]
+name = "potential_utf"
+version = "0.1.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b73949432f5e2a09657003c25bca5e19a0e9c84f8058ca374f49e0ebe605af77"
+dependencies = [
+ "zerovec",
+]
 
 [[package]]
 name = "proc-macro2"
@@ -425,6 +895,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "r-efi"
+version = "5.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "69cdb34c158ceb288df11e18b4bd39de994f6657d83847bdffdbd7f346754b0f"
+
+[[package]]
 name = "redox_syscall"
 version = "0.5.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -434,10 +910,123 @@ dependencies = [
 ]
 
 [[package]]
+name = "reqwest"
+version = "0.12.15"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d19c46a6fdd48bc4dab94b6103fccc55d34c67cc0ad04653aad4ea2a07cd7bbb"
+dependencies = [
+ "base64",
+ "bytes",
+ "encoding_rs",
+ "futures-core",
+ "futures-util",
+ "h2",
+ "http",
+ "http-body",
+ "http-body-util",
+ "hyper",
+ "hyper-rustls",
+ "hyper-tls",
+ "hyper-util",
+ "ipnet",
+ "js-sys",
+ "log",
+ "mime",
+ "native-tls",
+ "once_cell",
+ "percent-encoding",
+ "pin-project-lite",
+ "rustls-pemfile",
+ "serde",
+ "serde_json",
+ "serde_urlencoded",
+ "sync_wrapper",
+ "system-configuration",
+ "tokio",
+ "tokio-native-tls",
+ "tower",
+ "tower-service",
+ "url",
+ "wasm-bindgen",
+ "wasm-bindgen-futures",
+ "web-sys",
+ "windows-registry",
+]
+
+[[package]]
+name = "ring"
+version = "0.17.14"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a4689e6c2294d81e88dc6261c768b63bc4fcdb852be6d1352498b114f61383b7"
+dependencies = [
+ "cc",
+ "cfg-if",
+ "getrandom 0.2.16",
+ "libc",
+ "untrusted",
+ "windows-sys 0.52.0",
+]
+
+[[package]]
 name = "rustc-demangle"
 version = "0.1.24"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "719b953e2095829ee67db738b3bfa9fa368c94900df327b3f07fe6e794d2fe1f"
+
+[[package]]
+name = "rustix"
+version = "1.0.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "11181fbabf243db407ef8df94a6ce0b2f9a733bd8be4ad02b4eda9602296cac8"
+dependencies = [
+ "bitflags",
+ "errno",
+ "libc",
+ "linux-raw-sys",
+ "windows-sys 0.52.0",
+]
+
+[[package]]
+name = "rustls"
+version = "0.23.35"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "533f54bc6a7d4f647e46ad909549eda97bf5afc1585190ef692b4286b198bd8f"
+dependencies = [
+ "once_cell",
+ "rustls-pki-types",
+ "rustls-webpki",
+ "subtle",
+ "zeroize",
+]
+
+[[package]]
+name = "rustls-pemfile"
+version = "2.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "dce314e5fee3f39953d46bb63bb8a46d40c2f8fb7cc5a3b6cab2bde9721d6e50"
+dependencies = [
+ "rustls-pki-types",
+]
+
+[[package]]
+name = "rustls-pki-types"
+version = "1.13.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "94182ad936a0c91c324cd46c6511b9510ed16af436d7b5bab34beab0afd55f7a"
+dependencies = [
+ "zeroize",
+]
+
+[[package]]
+name = "rustls-webpki"
+version = "0.103.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2ffdfa2f5286e2247234e03f680868ac2815974dc39e00ea15adc445d0aafe52"
+dependencies = [
+ "ring",
+ "rustls-pki-types",
+ "untrusted",
+]
 
 [[package]]
 name = "rustversion"
@@ -452,10 +1041,42 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f3cb5ba0dc43242ce17de99c180e96db90b235b8a9fdc9543c96d2209116bd9f"
 
 [[package]]
+name = "schannel"
+version = "0.1.28"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "891d81b926048e76efe18581bf793546b4c0eaf8448d72be8de2bbee5fd166e1"
+dependencies = [
+ "windows-sys 0.61.2",
+]
+
+[[package]]
 name = "scopeguard"
 version = "1.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "94143f37725109f92c262ed2cf5e59bce7498c01bcc1502d7b9afe439a4e9f49"
+
+[[package]]
+name = "security-framework"
+version = "2.11.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "897b2245f0b511c87893af39b033e5ca9cce68824c4d7e7630b5a1d339658d02"
+dependencies = [
+ "bitflags",
+ "core-foundation",
+ "core-foundation-sys",
+ "libc",
+ "security-framework-sys",
+]
+
+[[package]]
+name = "security-framework-sys"
+version = "2.15.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cc1f0cbffaac4852523ce30d8bd3c5cdc873501d96ff467ca09b6767bb8cd5c0"
+dependencies = [
+ "core-foundation-sys",
+ "libc",
+]
 
 [[package]]
 name = "serde"
@@ -512,6 +1133,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "shlex"
+version = "1.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0fda2ff0d084019ba4d7c6f371c95d8fd75ce3524c3cb8fb653a3023f6323e64"
+
+[[package]]
 name = "signal-hook-registry"
 version = "1.4.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -519,6 +1146,12 @@ checksum = "a9e9e0b4211b72e7b8b6e85c807d36c212bdb33ea8587f7569562a84df5465b1"
 dependencies = [
  "libc",
 ]
+
+[[package]]
+name = "slab"
+version = "0.4.11"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7a2ae44ef20feb57a68b23d846850f861394c2e02dc425a50098ae8c90267589"
 
 [[package]]
 name = "smallvec"
@@ -533,8 +1166,20 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c970269d99b64e60ec3bd6ad27270092a5394c4e309314b18ae3fe575695fbe8"
 dependencies = [
  "libc",
- "windows-sys",
+ "windows-sys 0.52.0",
 ]
+
+[[package]]
+name = "stable_deref_trait"
+version = "1.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6ce2be8dc25455e1f91df71bfa12ad37d7af1092ae736f3a6cd0e37bc7810596"
+
+[[package]]
+name = "subtle"
+version = "2.6.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "13c2bddecc57b384dee18652358fb23172facb8a2c51ccc10d74c157bdea3292"
 
 [[package]]
 name = "syn"
@@ -552,16 +1197,67 @@ name = "sync_wrapper"
 version = "1.0.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0bf256ce5efdfa370213c1dabab5935a12e49f2c58d15e9eac2870d3b4f27263"
+dependencies = [
+ "futures-core",
+]
+
+[[package]]
+name = "synstructure"
+version = "0.13.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "728a70f3dbaf5bab7f0c4b1ac8d7ae5ea60a4b5549c8a5914361c99147a709d2"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
+name = "system-configuration"
+version = "0.6.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3c879d448e9d986b661742763247d3693ed13609438cf3d006f51f5368a5ba6b"
+dependencies = [
+ "bitflags",
+ "core-foundation",
+ "system-configuration-sys",
+]
+
+[[package]]
+name = "system-configuration-sys"
+version = "0.6.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8e1d1b10ced5ca923a1fcb8d03e96b8d3268065d724548c0211415ff6ac6bac4"
+dependencies = [
+ "core-foundation-sys",
+ "libc",
+]
 
 [[package]]
 name = "temperatures"
 version = "0.1.0"
 dependencies = [
  "axum",
+ "chrono",
  "parking_lot",
  "prometheus",
+ "reqwest",
  "serde",
+ "serde_json",
  "tokio",
+]
+
+[[package]]
+name = "tempfile"
+version = "3.23.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2d31c77bdf42a745371d260a26ca7163f1e0924b64afa0b688e61b5a9fa02f16"
+dependencies = [
+ "fastrand",
+ "getrandom 0.3.4",
+ "once_cell",
+ "rustix",
+ "windows-sys 0.52.0",
 ]
 
 [[package]]
@@ -585,6 +1281,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "tinystr"
+version = "0.8.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "42d3e9c45c09de15d06dd8acf5f4e0e399e85927b7f00711024eb7ae10fa4869"
+dependencies = [
+ "displaydoc",
+ "zerovec",
+]
+
+[[package]]
 name = "tokio"
 version = "1.42.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -599,7 +1305,7 @@ dependencies = [
  "signal-hook-registry",
  "socket2",
  "tokio-macros",
- "windows-sys",
+ "windows-sys 0.52.0",
 ]
 
 [[package]]
@@ -611,6 +1317,39 @@ dependencies = [
  "proc-macro2",
  "quote",
  "syn",
+]
+
+[[package]]
+name = "tokio-native-tls"
+version = "0.3.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bbae76ab933c85776efabc971569dd6119c580d8f5d448769dec1764bf796ef2"
+dependencies = [
+ "native-tls",
+ "tokio",
+]
+
+[[package]]
+name = "tokio-rustls"
+version = "0.26.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1729aa945f29d91ba541258c8df89027d5792d85a8841fb65e8bf0f4ede4ef61"
+dependencies = [
+ "rustls",
+ "tokio",
+]
+
+[[package]]
+name = "tokio-util"
+version = "0.7.17"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2efa149fe76073d6e8fd97ef4f4eca7b67f599660115591483572e406e165594"
+dependencies = [
+ "bytes",
+ "futures-core",
+ "futures-sink",
+ "pin-project-lite",
+ "tokio",
 ]
 
 [[package]]
@@ -662,10 +1401,54 @@ dependencies = [
 ]
 
 [[package]]
+name = "try-lock"
+version = "0.2.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e421abadd41a4225275504ea4d6566923418b7f05506fbc9c0fe86ba7396114b"
+
+[[package]]
 name = "unicode-ident"
 version = "1.0.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "adb9e6ca4f869e1180728b7950e35922a7fc6397f7b641499e8f3ef06e50dc83"
+
+[[package]]
+name = "untrusted"
+version = "0.9.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8ecb6da28b8a351d773b68d5825ac39017e680750f980f3a1a85cd8dd28a47c1"
+
+[[package]]
+name = "url"
+version = "2.5.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "32f8b686cadd1473f4bd0117a5d28d36b1ade384ea9b5069a1c40aefed7fda60"
+dependencies = [
+ "form_urlencoded",
+ "idna",
+ "percent-encoding",
+]
+
+[[package]]
+name = "utf8_iter"
+version = "1.0.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b6c140620e7ffbb22c2dee59cafe6084a59b5ffc27a8859a5f0d494b5d52b6be"
+
+[[package]]
+name = "vcpkg"
+version = "0.2.15"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "accd4ea62f7bb7a82fe23066fb0957d48ef677f6eeb8215f372f52e48bb32426"
+
+[[package]]
+name = "want"
+version = "0.3.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bfa7760aed19e106de2c7c0b581b509f2f25d3dacaf737cb82ac61bc6d760b0e"
+dependencies = [
+ "try-lock",
+]
 
 [[package]]
 name = "wasi"
@@ -674,12 +1457,192 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9c8d87e72b64a3b4db28d11ce29237c246188f4f51057d65a7eab63b7987e423"
 
 [[package]]
+name = "wasip2"
+version = "1.0.1+wasi-0.2.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0562428422c63773dad2c345a1882263bbf4d65cf3f42e90921f787ef5ad58e7"
+dependencies = [
+ "wit-bindgen",
+]
+
+[[package]]
+name = "wasm-bindgen"
+version = "0.2.105"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "da95793dfc411fbbd93f5be7715b0578ec61fe87cb1a42b12eb625caa5c5ea60"
+dependencies = [
+ "cfg-if",
+ "once_cell",
+ "rustversion",
+ "wasm-bindgen-macro",
+ "wasm-bindgen-shared",
+]
+
+[[package]]
+name = "wasm-bindgen-futures"
+version = "0.4.55"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "551f88106c6d5e7ccc7cd9a16f312dd3b5d36ea8b4954304657d5dfba115d4a0"
+dependencies = [
+ "cfg-if",
+ "js-sys",
+ "once_cell",
+ "wasm-bindgen",
+ "web-sys",
+]
+
+[[package]]
+name = "wasm-bindgen-macro"
+version = "0.2.105"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "04264334509e04a7bf8690f2384ef5265f05143a4bff3889ab7a3269adab59c2"
+dependencies = [
+ "quote",
+ "wasm-bindgen-macro-support",
+]
+
+[[package]]
+name = "wasm-bindgen-macro-support"
+version = "0.2.105"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "420bc339d9f322e562942d52e115d57e950d12d88983a14c79b86859ee6c7ebc"
+dependencies = [
+ "bumpalo",
+ "proc-macro2",
+ "quote",
+ "syn",
+ "wasm-bindgen-shared",
+]
+
+[[package]]
+name = "wasm-bindgen-shared"
+version = "0.2.105"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "76f218a38c84bcb33c25ec7059b07847d465ce0e0a76b995e134a45adcb6af76"
+dependencies = [
+ "unicode-ident",
+]
+
+[[package]]
+name = "web-sys"
+version = "0.3.82"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3a1f95c0d03a47f4ae1f7a64643a6bb97465d9b740f0fa8f90ea33915c99a9a1"
+dependencies = [
+ "js-sys",
+ "wasm-bindgen",
+]
+
+[[package]]
+name = "windows-core"
+version = "0.62.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b8e83a14d34d0623b51dce9581199302a221863196a1dde71a7663a4c2be9deb"
+dependencies = [
+ "windows-implement",
+ "windows-interface",
+ "windows-link 0.2.1",
+ "windows-result 0.4.1",
+ "windows-strings 0.5.1",
+]
+
+[[package]]
+name = "windows-implement"
+version = "0.60.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "053e2e040ab57b9dc951b72c264860db7eb3b0200ba345b4e4c3b14f67855ddf"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
+name = "windows-interface"
+version = "0.59.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3f316c4a2570ba26bbec722032c4099d8c8bc095efccdc15688708623367e358"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
+name = "windows-link"
+version = "0.1.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5e6ad25900d524eaabdbbb96d20b4311e1e7ae1699af4fb28c17ae66c80d798a"
+
+[[package]]
+name = "windows-link"
+version = "0.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f0805222e57f7521d6a62e36fa9163bc891acd422f971defe97d64e70d0a4fe5"
+
+[[package]]
+name = "windows-registry"
+version = "0.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4286ad90ddb45071efd1a66dfa43eb02dd0dfbae1545ad6cc3c51cf34d7e8ba3"
+dependencies = [
+ "windows-result 0.3.4",
+ "windows-strings 0.3.1",
+ "windows-targets 0.53.5",
+]
+
+[[package]]
+name = "windows-result"
+version = "0.3.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "56f42bd332cc6c8eac5af113fc0c1fd6a8fd2aa08a0119358686e5160d0586c6"
+dependencies = [
+ "windows-link 0.1.3",
+]
+
+[[package]]
+name = "windows-result"
+version = "0.4.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7781fa89eaf60850ac3d2da7af8e5242a5ea78d1a11c49bf2910bb5a73853eb5"
+dependencies = [
+ "windows-link 0.2.1",
+]
+
+[[package]]
+name = "windows-strings"
+version = "0.3.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "87fa48cc5d406560701792be122a10132491cff9d0aeb23583cc2dcafc847319"
+dependencies = [
+ "windows-link 0.1.3",
+]
+
+[[package]]
+name = "windows-strings"
+version = "0.5.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7837d08f69c77cf6b07689544538e017c1bfcf57e34b4c0ff58e6c2cd3b37091"
+dependencies = [
+ "windows-link 0.2.1",
+]
+
+[[package]]
 name = "windows-sys"
 version = "0.52.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "282be5f36a8ce781fad8c8ae18fa3f9beff57ec1b52cb3de0789201425d9a33d"
 dependencies = [
- "windows-targets",
+ "windows-targets 0.52.6",
+]
+
+[[package]]
+name = "windows-sys"
+version = "0.61.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ae137229bcbd6cdf0f7b80a31df61766145077ddf49416a728b02cb3921ff3fc"
+dependencies = [
+ "windows-link 0.2.1",
 ]
 
 [[package]]
@@ -688,14 +1651,31 @@ version = "0.52.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9b724f72796e036ab90c1021d4780d4d3d648aca59e491e6b98e725b84e99973"
 dependencies = [
- "windows_aarch64_gnullvm",
- "windows_aarch64_msvc",
- "windows_i686_gnu",
- "windows_i686_gnullvm",
- "windows_i686_msvc",
- "windows_x86_64_gnu",
- "windows_x86_64_gnullvm",
- "windows_x86_64_msvc",
+ "windows_aarch64_gnullvm 0.52.6",
+ "windows_aarch64_msvc 0.52.6",
+ "windows_i686_gnu 0.52.6",
+ "windows_i686_gnullvm 0.52.6",
+ "windows_i686_msvc 0.52.6",
+ "windows_x86_64_gnu 0.52.6",
+ "windows_x86_64_gnullvm 0.52.6",
+ "windows_x86_64_msvc 0.52.6",
+]
+
+[[package]]
+name = "windows-targets"
+version = "0.53.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4945f9f551b88e0d65f3db0bc25c33b8acea4d9e41163edf90dcd0b19f9069f3"
+dependencies = [
+ "windows-link 0.2.1",
+ "windows_aarch64_gnullvm 0.53.1",
+ "windows_aarch64_msvc 0.53.1",
+ "windows_i686_gnu 0.53.1",
+ "windows_i686_gnullvm 0.53.1",
+ "windows_i686_msvc 0.53.1",
+ "windows_x86_64_gnu 0.53.1",
+ "windows_x86_64_gnullvm 0.53.1",
+ "windows_x86_64_msvc 0.53.1",
 ]
 
 [[package]]
@@ -705,10 +1685,22 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "32a4622180e7a0ec044bb555404c800bc9fd9ec262ec147edd5989ccd0c02cd3"
 
 [[package]]
+name = "windows_aarch64_gnullvm"
+version = "0.53.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a9d8416fa8b42f5c947f8482c43e7d89e73a173cead56d044f6a56104a6d1b53"
+
+[[package]]
 name = "windows_aarch64_msvc"
 version = "0.52.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "09ec2a7bb152e2252b53fa7803150007879548bc709c039df7627cabbd05d469"
+
+[[package]]
+name = "windows_aarch64_msvc"
+version = "0.53.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b9d782e804c2f632e395708e99a94275910eb9100b2114651e04744e9b125006"
 
 [[package]]
 name = "windows_i686_gnu"
@@ -717,10 +1709,22 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8e9b5ad5ab802e97eb8e295ac6720e509ee4c243f69d781394014ebfe8bbfa0b"
 
 [[package]]
+name = "windows_i686_gnu"
+version = "0.53.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "960e6da069d81e09becb0ca57a65220ddff016ff2d6af6a223cf372a506593a3"
+
+[[package]]
 name = "windows_i686_gnullvm"
 version = "0.52.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0eee52d38c090b3caa76c563b86c3a4bd71ef1a819287c19d586d7334ae8ed66"
+
+[[package]]
+name = "windows_i686_gnullvm"
+version = "0.53.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fa7359d10048f68ab8b09fa71c3daccfb0e9b559aed648a8f95469c27057180c"
 
 [[package]]
 name = "windows_i686_msvc"
@@ -729,10 +1733,22 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "240948bc05c5e7c6dabba28bf89d89ffce3e303022809e73deaefe4f6ec56c66"
 
 [[package]]
+name = "windows_i686_msvc"
+version = "0.53.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1e7ac75179f18232fe9c285163565a57ef8d3c89254a30685b57d83a38d326c2"
+
+[[package]]
 name = "windows_x86_64_gnu"
 version = "0.52.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "147a5c80aabfbf0c7d901cb5895d1de30ef2907eb21fbbab29ca94c5b08b1a78"
+
+[[package]]
+name = "windows_x86_64_gnu"
+version = "0.53.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9c3842cdd74a865a8066ab39c8a7a473c0778a3f29370b5fd6b4b9aa7df4a499"
 
 [[package]]
 name = "windows_x86_64_gnullvm"
@@ -741,7 +1757,114 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "24d5b23dc417412679681396f2b49f3de8c1473deb516bd34410872eff51ed0d"
 
 [[package]]
+name = "windows_x86_64_gnullvm"
+version = "0.53.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0ffa179e2d07eee8ad8f57493436566c7cc30ac536a3379fdf008f47f6bb7ae1"
+
+[[package]]
 name = "windows_x86_64_msvc"
 version = "0.52.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "589f6da84c646204747d1270a2a5661ea66ed1cced2631d546fdfb155959f9ec"
+
+[[package]]
+name = "windows_x86_64_msvc"
+version = "0.53.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d6bbff5f0aada427a1e5a6da5f1f98158182f26556f345ac9e04d36d0ebed650"
+
+[[package]]
+name = "wit-bindgen"
+version = "0.46.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f17a85883d4e6d00e8a97c586de764dabcc06133f7f1d55dce5cdc070ad7fe59"
+
+[[package]]
+name = "writeable"
+version = "0.6.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9edde0db4769d2dc68579893f2306b26c6ecfbe0ef499b013d731b7b9247e0b9"
+
+[[package]]
+name = "yoke"
+version = "0.8.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "72d6e5c6afb84d73944e5cedb052c4680d5657337201555f9f2a16b7406d4954"
+dependencies = [
+ "stable_deref_trait",
+ "yoke-derive",
+ "zerofrom",
+]
+
+[[package]]
+name = "yoke-derive"
+version = "0.8.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b659052874eb698efe5b9e8cf382204678a0086ebf46982b79d6ca3182927e5d"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+ "synstructure",
+]
+
+[[package]]
+name = "zerofrom"
+version = "0.1.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "50cc42e0333e05660c3587f3bf9d0478688e15d870fab3346451ce7f8c9fbea5"
+dependencies = [
+ "zerofrom-derive",
+]
+
+[[package]]
+name = "zerofrom-derive"
+version = "0.1.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d71e5d6e06ab090c67b5e44993ec16b72dcbaabc526db883a360057678b48502"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+ "synstructure",
+]
+
+[[package]]
+name = "zeroize"
+version = "1.8.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b97154e67e32c85465826e8bcc1c59429aaaf107c1e4a9e53c8d8ccd5eff88d0"
+
+[[package]]
+name = "zerotrie"
+version = "0.2.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2a59c17a5562d507e4b54960e8569ebee33bee890c70aa3fe7b97e85a9fd7851"
+dependencies = [
+ "displaydoc",
+ "yoke",
+ "zerofrom",
+]
+
+[[package]]
+name = "zerovec"
+version = "0.11.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6c28719294829477f525be0186d13efa9a3c602f7ec202ca9e353d310fb9a002"
+dependencies = [
+ "yoke",
+ "zerofrom",
+ "zerovec-derive",
+]
+
+[[package]]
+name = "zerovec-derive"
+version = "0.11.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "eadce39539ca5cb3985590102671f2567e659fca9666581ad3411d59207951f3"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -7,5 +7,8 @@ edition = "2021"
 axum = { version = "0.7", features = ["json"] }
 tokio = { version = "1.0", features = ["full"] }
 serde = { version = "1.0", features = ["derive"] }
+serde_json = "1.0"
 parking_lot = "0.12"
 prometheus = "0.13"
+reqwest = { version = "0.12", features = ["json"] }
+chrono = { version = "0.4", features = ["serde"] }

--- a/Readme.md
+++ b/Readme.md
@@ -1,2 +1,54 @@
-Simple prometheus exporter for temperature sensors using w1-gpio.
+Simple prometheus exporter for temperature sensors using w1-gpio and Airthings air quality sensors.
+
 I got tired of owserver and homeassistant fighting. So decided to skip the homeassistant step and just use prometheus.
+
+## Features
+
+- **W1-GPIO Temperature Sensors**: Reads temperature data from 1-Wire temperature sensors (e.g., DS18B20)
+- **Airthings Integration**: Fetches air quality data from Airthings devices via their Consumer API
+
+## Configuration
+
+### W1-GPIO Sensors
+No configuration needed. The exporter automatically detects sensors in `/sys/bus/w1/devices/`.
+
+### Airthings Integration
+To enable Airthings monitoring, you need to obtain API credentials:
+
+1. Sign in to the [Airthings Dashboard](https://dashboard.airthings.com/)
+2. Navigate to Integrations > API
+3. Create a new API client and note your `Client ID` and `Client Secret`
+4. Set the following environment variables:
+   ```bash
+   export AIRTHINGS_CLIENT_ID="your_client_id"
+   export AIRTHINGS_CLIENT_SECRET="your_client_secret"
+   ```
+
+If these environment variables are not set, the exporter will skip Airthings monitoring and only export w1-gpio sensor data.
+
+## Metrics
+
+The exporter provides the following metrics at `http://localhost:9091/metrics`:
+
+### W1-GPIO Temperature Sensors
+- `temperature_celsius{sensor="<sensor_id>"}` - Temperature in degrees Celsius
+
+### Airthings Sensors
+- `airthings_temperature_celsius{device_id="<id>", device_type="<type>"}` - Temperature in °C
+- `airthings_humidity_percent{device_id="<id>", device_type="<type>"}` - Relative humidity in %
+- `airthings_co2_ppm{device_id="<id>", device_type="<type>"}` - CO2 concentration in ppm
+- `airthings_voc_ppb{device_id="<id>", device_type="<type>"}` - VOC concentration in ppb
+- `airthings_pressure_hpa{device_id="<id>", device_type="<type>"}` - Atmospheric pressure in hPa
+- `airthings_radon_bqm3{device_id="<id>", device_type="<type>"}` - Radon short term average in Bq/m³
+- `airthings_pm1_ugm3{device_id="<id>", device_type="<type>"}` - PM1 particulate matter in µg/m³
+- `airthings_pm25_ugm3{device_id="<id>", device_type="<type>"}` - PM2.5 particulate matter in µg/m³
+- `airthings_battery_percent{device_id="<id>", device_type="<type>"}` - Battery level in %
+
+## Running
+
+```bash
+cargo build --release
+./target/release/temperatures
+```
+
+The server will start on port 9091.

--- a/Readme.md
+++ b/Readme.md
@@ -34,15 +34,18 @@ The exporter provides the following metrics at `http://localhost:9091/metrics`:
 - `temperature_celsius{sensor="<sensor_id>"}` - Temperature in degrees Celsius
 
 ### Airthings Sensors
-- `airthings_temperature_celsius{device_id="<id>", device_type="<type>"}` - Temperature in °C
-- `airthings_humidity_percent{device_id="<id>", device_type="<type>"}` - Relative humidity in %
-- `airthings_co2_ppm{device_id="<id>", device_type="<type>"}` - CO2 concentration in ppm
-- `airthings_voc_ppb{device_id="<id>", device_type="<type>"}` - VOC concentration in ppb
-- `airthings_pressure_hpa{device_id="<id>", device_type="<type>"}` - Atmospheric pressure in hPa
-- `airthings_radon_bqm3{device_id="<id>", device_type="<type>"}` - Radon short term average in Bq/m³
-- `airthings_pm1_ugm3{device_id="<id>", device_type="<type>"}` - PM1 particulate matter in µg/m³
-- `airthings_pm25_ugm3{device_id="<id>", device_type="<type>"}` - PM2.5 particulate matter in µg/m³
-- `airthings_battery_percent{device_id="<id>", device_type="<type>"}` - Battery level in %
+Metrics are dynamically created based on the sensors available for each device. Common metrics include:
+- `airthings_temp{device_id="<id>", device_type="<type>"}` - Temperature
+- `airthings_humidity{device_id="<id>", device_type="<type>"}` - Relative humidity
+- `airthings_co2{device_id="<id>", device_type="<type>"}` - CO2 concentration
+- `airthings_voc{device_id="<id>", device_type="<type>"}` - Volatile Organic Compounds
+- `airthings_pressure{device_id="<id>", device_type="<type>"}` - Atmospheric pressure
+- `airthings_radonShortTermAvg{device_id="<id>", device_type="<type>"}` - Radon short term average
+- `airthings_pm1{device_id="<id>", device_type="<type>"}` - PM1 particulate matter
+- `airthings_pm25{device_id="<id>", device_type="<type>"}` - PM2.5 particulate matter
+- `airthings_battery_percent{device_id="<id>", device_type="<type>"}` - Battery level
+
+Available sensors vary by device type. The metric names match the sensor types returned by the Airthings API.
 
 ## Running
 

--- a/Readme.md
+++ b/Readme.md
@@ -35,17 +35,17 @@ The exporter provides the following metrics at `http://localhost:9091/metrics`:
 
 ### Airthings Sensors
 Metrics are dynamically created based on the sensors available for each device. Common metrics include:
-- `airthings_temp{device_id="<id>", device_type="<type>"}` - Temperature
-- `airthings_humidity{device_id="<id>", device_type="<type>"}` - Relative humidity
-- `airthings_co2{device_id="<id>", device_type="<type>"}` - CO2 concentration
-- `airthings_voc{device_id="<id>", device_type="<type>"}` - Volatile Organic Compounds
-- `airthings_pressure{device_id="<id>", device_type="<type>"}` - Atmospheric pressure
-- `airthings_radonShortTermAvg{device_id="<id>", device_type="<type>"}` - Radon short term average
-- `airthings_pm1{device_id="<id>", device_type="<type>"}` - PM1 particulate matter
-- `airthings_pm25{device_id="<id>", device_type="<type>"}` - PM2.5 particulate matter
-- `airthings_battery_percent{device_id="<id>", device_type="<type>"}` - Battery level
+- `airthings_temp{device_id="<id>", device_type="<type>", device_name="<name>"}` - Temperature
+- `airthings_humidity{device_id="<id>", device_type="<type>", device_name="<name>"}` - Relative humidity
+- `airthings_co2{device_id="<id>", device_type="<type>", device_name="<name>"}` - CO2 concentration
+- `airthings_voc{device_id="<id>", device_type="<type>", device_name="<name>"}` - Volatile Organic Compounds
+- `airthings_pressure{device_id="<id>", device_type="<type>", device_name="<name>"}` - Atmospheric pressure
+- `airthings_radonShortTermAvg{device_id="<id>", device_type="<type>", device_name="<name>"}` - Radon short term average
+- `airthings_pm1{device_id="<id>", device_type="<type>", device_name="<name>"}` - PM1 particulate matter
+- `airthings_pm25{device_id="<id>", device_type="<type>", device_name="<name>"}` - PM2.5 particulate matter
+- `airthings_battery_percent{device_id="<id>", device_type="<type>", device_name="<name>"}` - Battery level
 
-Available sensors vary by device type. The metric names match the sensor types returned by the Airthings API.
+Available sensors vary by device type. The metric names match the sensor types returned by the Airthings API. Each metric includes the device name for easy identification in Grafana and other monitoring tools.
 
 ## Running
 

--- a/src/airthings.rs
+++ b/src/airthings.rs
@@ -91,12 +91,7 @@ impl AirthingsClient {
             ("scope", "read:device:current_values"),
         ];
 
-        let response = self
-            .client
-            .post(TOKEN_URL)
-            .form(&params)
-            .send()
-            .await?;
+        let response = self.client.post(TOKEN_URL).form(&params).send().await?;
 
         if !response.status().is_success() {
             let status = response.status();

--- a/src/airthings.rs
+++ b/src/airthings.rs
@@ -49,7 +49,6 @@ pub struct Device {
     pub device_type: String,
     #[allow(dead_code)]
     pub sensors: Vec<String>,
-    #[allow(dead_code)]
     pub name: String,
     #[allow(dead_code)]
     pub home: Option<String>,

--- a/src/airthings.rs
+++ b/src/airthings.rs
@@ -1,0 +1,167 @@
+use reqwest::Client;
+use serde::{Deserialize, Serialize};
+use std::error::Error;
+use std::time::{Duration, SystemTime};
+
+type BoxError = Box<dyn Error + Send + Sync>;
+
+const TOKEN_URL: &str = "https://accounts-api.airthings.com/v1/token";
+const API_BASE_URL: &str = "https://ext-api.airthings.com/v1";
+
+#[derive(Debug, Clone)]
+pub struct AirthingsConfig {
+    pub client_id: String,
+    pub client_secret: String,
+}
+
+#[derive(Debug, Serialize, Deserialize)]
+struct TokenResponse {
+    access_token: String,
+    expires_in: u64,
+}
+
+#[derive(Debug)]
+struct AccessToken {
+    token: String,
+    expires_at: SystemTime,
+}
+
+#[derive(Debug, Deserialize)]
+pub struct Device {
+    pub id: String,
+    #[serde(rename = "deviceType")]
+    pub device_type: String,
+    pub sensors: Vec<Sensor>,
+}
+
+#[derive(Debug, Deserialize)]
+pub struct Sensor {
+    pub id: String,
+    #[serde(rename = "type")]
+    pub sensor_type: String,
+}
+
+#[derive(Debug, Deserialize)]
+pub struct DeviceLatestSamples {
+    pub data: SampleData,
+}
+
+#[derive(Debug, Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub struct SampleData {
+    pub battery: Option<f64>,
+    pub co2: Option<f64>,
+    pub humidity: Option<f64>,
+    pub pm1: Option<f64>,
+    pub pm25: Option<f64>,
+    pub pressure: Option<f64>,
+    pub radon_short_term_avg: Option<f64>,
+    pub temp: Option<f64>,
+    pub voc: Option<f64>,
+}
+
+pub struct AirthingsClient {
+    config: AirthingsConfig,
+    client: Client,
+    access_token: Option<AccessToken>,
+}
+
+impl AirthingsClient {
+    pub fn new(config: AirthingsConfig) -> Self {
+        Self {
+            config,
+            client: Client::new(),
+            access_token: None,
+        }
+    }
+
+    async fn get_access_token(&mut self) -> Result<String, BoxError> {
+        // Check if we have a valid token
+        if let Some(token) = &self.access_token {
+            if token.expires_at > SystemTime::now() {
+                return Ok(token.token.clone());
+            }
+        }
+
+        // Request new token using client credentials flow
+        let params = [
+            ("grant_type", "client_credentials"),
+            ("client_id", &self.config.client_id),
+            ("client_secret", &self.config.client_secret),
+            ("scope", "read:device:current_values"),
+        ];
+
+        let response = self
+            .client
+            .post(TOKEN_URL)
+            .form(&params)
+            .send()
+            .await?;
+
+        if !response.status().is_success() {
+            let status = response.status();
+            let text = response.text().await?;
+            return Err(format!("Token request failed with status {}: {}", status, text).into());
+        }
+
+        let token_response: TokenResponse = response.json().await?;
+
+        let expires_at = SystemTime::now() + Duration::from_secs(token_response.expires_in - 60);
+        self.access_token = Some(AccessToken {
+            token: token_response.access_token.clone(),
+            expires_at,
+        });
+
+        Ok(token_response.access_token)
+    }
+
+    pub async fn get_devices(&mut self) -> Result<Vec<Device>, BoxError> {
+        let token = self.get_access_token().await?;
+
+        let response = self
+            .client
+            .get(format!("{}/devices", API_BASE_URL))
+            .bearer_auth(&token)
+            .send()
+            .await?;
+
+        if !response.status().is_success() {
+            let status = response.status();
+            let text = response.text().await?;
+            return Err(format!("Failed to get devices: {} - {}", status, text).into());
+        }
+
+        let devices: Vec<Device> = response.json().await?;
+        Ok(devices)
+    }
+
+    pub async fn get_latest_samples(
+        &mut self,
+        device_id: &str,
+    ) -> Result<DeviceLatestSamples, BoxError> {
+        let token = self.get_access_token().await?;
+
+        let response = self
+            .client
+            .get(format!(
+                "{}/devices/{}/latest-samples",
+                API_BASE_URL, device_id
+            ))
+            .bearer_auth(&token)
+            .send()
+            .await?;
+
+        if !response.status().is_success() {
+            let status = response.status();
+            let text = response.text().await?;
+            return Err(format!(
+                "Failed to get latest samples for device {}: {} - {}",
+                device_id, status, text
+            )
+            .into());
+        }
+
+        let samples: DeviceLatestSamples = response.json().await?;
+        Ok(samples)
+    }
+}

--- a/src/airthings.rs
+++ b/src/airthings.rs
@@ -27,18 +27,18 @@ struct AccessToken {
 }
 
 #[derive(Debug, Deserialize)]
-pub struct Device {
-    pub id: String,
-    #[serde(rename = "deviceType")]
-    pub device_type: String,
-    pub sensors: Vec<Sensor>,
+struct DevicesResponse {
+    devices: Vec<Device>,
 }
 
 #[derive(Debug, Deserialize)]
-pub struct Sensor {
+pub struct Device {
+    #[serde(rename = "serialNumber")]
     pub id: String,
     #[serde(rename = "type")]
-    pub sensor_type: String,
+    pub device_type: String,
+    #[allow(dead_code)]
+    pub sensors: Vec<String>,
 }
 
 #[derive(Debug, Deserialize)]
@@ -126,8 +126,14 @@ impl AirthingsClient {
             return Err(format!("Failed to get devices: {} - {}", status, text).into());
         }
 
-        let devices: Vec<Device> = response.json().await?;
-        Ok(devices)
+        let text = response.text().await?;
+        let devices_response: DevicesResponse = serde_json::from_str(&text).map_err(|e| {
+            format!(
+                "Failed to parse devices response: {}. Response body: {}",
+                e, text
+            )
+        })?;
+        Ok(devices_response.devices)
     }
 
     pub async fn get_latest_samples(
@@ -156,7 +162,13 @@ impl AirthingsClient {
             .into());
         }
 
-        let samples: DeviceLatestSamples = response.json().await?;
+        let text = response.text().await?;
+        let samples: DeviceLatestSamples = serde_json::from_str(&text).map_err(|e| {
+            format!(
+                "Failed to parse latest samples for device {}: {}. Response body: {}",
+                device_id, e, text
+            )
+        })?;
         Ok(samples)
     }
 }

--- a/src/airthings.rs
+++ b/src/airthings.rs
@@ -6,7 +6,7 @@ use std::time::{Duration, SystemTime};
 type BoxError = Box<dyn Error + Send + Sync>;
 
 const TOKEN_URL: &str = "https://accounts-api.airthings.com/v1/token";
-const API_BASE_URL: &str = "https://ext-api.airthings.com/v1";
+const API_BASE_URL: &str = "https://consumer-api.airthings.com/v1";
 
 #[derive(Debug, Clone)]
 pub struct AirthingsConfig {
@@ -27,6 +27,16 @@ struct AccessToken {
 }
 
 #[derive(Debug, Deserialize)]
+struct AccountsResponse {
+    accounts: Vec<AccountResponse>,
+}
+
+#[derive(Debug, Deserialize)]
+struct AccountResponse {
+    id: String,
+}
+
+#[derive(Debug, Deserialize)]
 struct DevicesResponse {
     devices: Vec<Device>,
 }
@@ -39,31 +49,40 @@ pub struct Device {
     pub device_type: String,
     #[allow(dead_code)]
     pub sensors: Vec<String>,
+    #[allow(dead_code)]
+    pub name: String,
+    #[allow(dead_code)]
+    pub home: Option<String>,
 }
 
 #[derive(Debug, Deserialize)]
-pub struct DeviceLatestSamples {
-    pub data: SampleData,
+struct SensorsResponse {
+    results: Vec<DeviceSensors>,
 }
 
 #[derive(Debug, Deserialize)]
 #[serde(rename_all = "camelCase")]
-pub struct SampleData {
-    pub battery: Option<f64>,
-    pub co2: Option<f64>,
-    pub humidity: Option<f64>,
-    pub pm1: Option<f64>,
-    pub pm25: Option<f64>,
-    pub pressure: Option<f64>,
-    pub radon_short_term_avg: Option<f64>,
-    pub temp: Option<f64>,
-    pub voc: Option<f64>,
+pub struct DeviceSensors {
+    pub serial_number: String,
+    pub sensors: Vec<SensorResponse>,
+    #[allow(dead_code)]
+    pub battery_percentage: Option<i32>,
+}
+
+#[derive(Debug, Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub struct SensorResponse {
+    pub sensor_type: String,
+    pub value: f64,
+    #[allow(dead_code)]
+    pub unit: String,
 }
 
 pub struct AirthingsClient {
     config: AirthingsConfig,
     client: Client,
     access_token: Option<AccessToken>,
+    account_id: Option<String>,
 }
 
 impl AirthingsClient {
@@ -72,6 +91,7 @@ impl AirthingsClient {
             config,
             client: Client::new(),
             access_token: None,
+            account_id: None,
         }
     }
 
@@ -110,12 +130,53 @@ impl AirthingsClient {
         Ok(token_response.access_token)
     }
 
-    pub async fn get_devices(&mut self) -> Result<Vec<Device>, BoxError> {
+    async fn get_account_id(&mut self) -> Result<String, BoxError> {
+        // Return cached account ID if available
+        if let Some(account_id) = &self.account_id {
+            return Ok(account_id.clone());
+        }
+
         let token = self.get_access_token().await?;
 
         let response = self
             .client
-            .get(format!("{}/devices", API_BASE_URL))
+            .get(format!("{}/accounts", API_BASE_URL))
+            .bearer_auth(&token)
+            .send()
+            .await?;
+
+        if !response.status().is_success() {
+            let status = response.status();
+            let text = response.text().await?;
+            return Err(format!("Failed to get accounts: {} - {}", status, text).into());
+        }
+
+        let text = response.text().await?;
+        let accounts_response: AccountsResponse = serde_json::from_str(&text).map_err(|e| {
+            format!(
+                "Failed to parse accounts response: {}. Response body: {}",
+                e, text
+            )
+        })?;
+
+        let account_id = accounts_response
+            .accounts
+            .first()
+            .ok_or("No accounts found")?
+            .id
+            .clone();
+
+        self.account_id = Some(account_id.clone());
+        Ok(account_id)
+    }
+
+    pub async fn get_devices(&mut self) -> Result<Vec<Device>, BoxError> {
+        let account_id = self.get_account_id().await?;
+        let token = self.get_access_token().await?;
+
+        let response = self
+            .client
+            .get(format!("{}/accounts/{}/devices", API_BASE_URL, account_id))
             .bearer_auth(&token)
             .send()
             .await?;
@@ -136,39 +197,41 @@ impl AirthingsClient {
         Ok(devices_response.devices)
     }
 
-    pub async fn get_latest_samples(
+    pub async fn get_sensors(
         &mut self,
-        device_id: &str,
-    ) -> Result<DeviceLatestSamples, BoxError> {
+        serial_numbers: &[String],
+    ) -> Result<Vec<DeviceSensors>, BoxError> {
+        let account_id = self.get_account_id().await?;
         let token = self.get_access_token().await?;
 
-        let response = self
-            .client
-            .get(format!(
-                "{}/devices/{}/latest-samples",
-                API_BASE_URL, device_id
-            ))
-            .bearer_auth(&token)
-            .send()
-            .await?;
+        let mut url = format!("{}/accounts/{}/sensors", API_BASE_URL, account_id);
+
+        // Add serial numbers as query parameters
+        if !serial_numbers.is_empty() {
+            url.push('?');
+            for (i, sn) in serial_numbers.iter().enumerate() {
+                if i > 0 {
+                    url.push('&');
+                }
+                url.push_str(&format!("sn={}", sn));
+            }
+        }
+
+        let response = self.client.get(&url).bearer_auth(&token).send().await?;
 
         if !response.status().is_success() {
             let status = response.status();
             let text = response.text().await?;
-            return Err(format!(
-                "Failed to get latest samples for device {}: {} - {}",
-                device_id, status, text
-            )
-            .into());
+            return Err(format!("Failed to get sensors: {} - {}", status, text).into());
         }
 
         let text = response.text().await?;
-        let samples: DeviceLatestSamples = serde_json::from_str(&text).map_err(|e| {
+        let sensors_response: SensorsResponse = serde_json::from_str(&text).map_err(|e| {
             format!(
-                "Failed to parse latest samples for device {}: {}. Response body: {}",
-                device_id, e, text
+                "Failed to parse sensors response: {}. Response body: {}",
+                e, text
             )
         })?;
-        Ok(samples)
+        Ok(sensors_response.results)
     }
 }

--- a/src/main.rs
+++ b/src/main.rs
@@ -79,16 +79,28 @@ async fn update_temperatures(devices_path: &Path, state: AppState) {
     }
 }
 
+fn sanitize_label_value(value: &str) -> String {
+    // Replace characters that might cause issues in Prometheus labels
+    // While Prometheus allows most characters in label values, we sanitize for safety
+    value
+        .trim()
+        .replace(' ', "_")
+        .replace('"', "")
+        .replace('\\', "")
+        .replace('\n', "")
+        .replace('\r', "")
+}
+
 async fn update_airthings(mut client: AirthingsClient, state: AppState) {
     loop {
         match client.get_devices().await {
             Ok(devices) => {
                 let serial_numbers: Vec<String> = devices.iter().map(|d| d.id.clone()).collect();
 
-                // Build device type lookup
-                let device_types: HashMap<String, String> = devices
+                // Build device metadata lookups
+                let device_info: HashMap<String, (String, String)> = devices
                     .iter()
-                    .map(|d| (d.id.clone(), d.device_type.clone()))
+                    .map(|d| (d.id.clone(), (d.device_type.clone(), d.name.clone())))
                     .collect();
 
                 match client.get_sensors(&serial_numbers).await {
@@ -96,10 +108,12 @@ async fn update_airthings(mut client: AirthingsClient, state: AppState) {
                         let mut gauges = state.airthings_gauges.write();
 
                         for device_sensors in sensors_data {
-                            let device_type = device_types
+                            let (device_type, device_name_raw) = device_info
                                 .get(&device_sensors.serial_number)
-                                .map(|s| s.as_str())
-                                .unwrap_or("unknown");
+                                .map(|(t, n)| (t.as_str(), n.as_str()))
+                                .unwrap_or(("unknown", "unknown"));
+
+                            let device_name = sanitize_label_value(device_name_raw);
 
                             // Update battery gauge if available
                             if let Some(battery) = device_sensors.battery_percentage {
@@ -113,15 +127,16 @@ async fn update_airthings(mut client: AirthingsClient, state: AppState) {
                                         "Battery level percentage",
                                     )
                                     .const_label("device_id", &device_sensors.serial_number)
-                                    .const_label("device_type", device_type);
+                                    .const_label("device_type", device_type)
+                                    .const_label("device_name", &device_name);
                                     let gauge = Gauge::with_opts(opts).unwrap();
                                     state.registry.register(Box::new(gauge.clone())).unwrap();
                                     gauge
                                 });
                                 gauge.set(battery as f64);
                                 println!(
-                                    "Battery for device {}: {}%",
-                                    device_sensors.serial_number, battery
+                                    "Battery for {} ({}): {}%",
+                                    device_name, device_sensors.serial_number, battery
                                 );
                             }
 
@@ -135,7 +150,8 @@ async fn update_airthings(mut client: AirthingsClient, state: AppState) {
                                     let help = format!("{} in {}", sensor.sensor_type, sensor.unit);
                                     let opts = Opts::new(&metric_name, &help)
                                         .const_label("device_id", &device_sensors.serial_number)
-                                        .const_label("device_type", device_type);
+                                        .const_label("device_type", device_type)
+                                        .const_label("device_name", &device_name);
                                     let gauge = Gauge::with_opts(opts).unwrap();
                                     state.registry.register(Box::new(gauge.clone())).unwrap();
                                     gauge
@@ -143,8 +159,9 @@ async fn update_airthings(mut client: AirthingsClient, state: AppState) {
 
                                 gauge.set(sensor.value);
                                 println!(
-                                    "{} for device {}: {:.2} {}",
+                                    "{} for {} ({}): {:.2} {}",
                                     sensor.sensor_type,
+                                    device_name,
                                     device_sensors.serial_number,
                                     sensor.value,
                                     sensor.unit

--- a/src/main.rs
+++ b/src/main.rs
@@ -83,96 +83,76 @@ async fn update_airthings(mut client: AirthingsClient, state: AppState) {
     loop {
         match client.get_devices().await {
             Ok(devices) => {
-                for device in devices {
-                    match client.get_latest_samples(&device.id).await {
-                        Ok(samples) => {
-                            let mut gauges = state.airthings_gauges.write();
-                            let data = samples.data;
+                let serial_numbers: Vec<String> = devices.iter().map(|d| d.id.clone()).collect();
 
-                            // Helper macro to create/update gauge
-                            macro_rules! update_gauge {
-                                ($field:expr, $name:expr, $help:expr, $unit:expr) => {
-                                    if let Some(value) = $field {
-                                        let key = format!("{}_{}", device.id, $name);
-                                        let gauge = gauges.entry(key).or_insert_with(|| {
-                                            let opts = Opts::new($name, $help)
-                                                .const_label("device_id", &device.id)
-                                                .const_label("device_type", &device.device_type);
-                                            let gauge = Gauge::with_opts(opts).unwrap();
-                                            state
-                                                .registry
-                                                .register(Box::new(gauge.clone()))
-                                                .unwrap();
-                                            gauge
-                                        });
-                                        gauge.set(value);
-                                        println!(
-                                            "{} for device {}: {:.2} {}",
-                                            $name, device.id, value, $unit
-                                        );
-                                    }
-                                };
+                // Build device type lookup
+                let device_types: HashMap<String, String> = devices
+                    .iter()
+                    .map(|d| (d.id.clone(), d.device_type.clone()))
+                    .collect();
+
+                match client.get_sensors(&serial_numbers).await {
+                    Ok(sensors_data) => {
+                        let mut gauges = state.airthings_gauges.write();
+
+                        for device_sensors in sensors_data {
+                            let device_type = device_types
+                                .get(&device_sensors.serial_number)
+                                .map(|s| s.as_str())
+                                .unwrap_or("unknown");
+
+                            // Update battery gauge if available
+                            if let Some(battery) = device_sensors.battery_percentage {
+                                let key = format!(
+                                    "{}_airthings_battery_percent",
+                                    device_sensors.serial_number
+                                );
+                                let gauge = gauges.entry(key).or_insert_with(|| {
+                                    let opts = Opts::new(
+                                        "airthings_battery_percent",
+                                        "Battery level percentage",
+                                    )
+                                    .const_label("device_id", &device_sensors.serial_number)
+                                    .const_label("device_type", device_type);
+                                    let gauge = Gauge::with_opts(opts).unwrap();
+                                    state.registry.register(Box::new(gauge.clone())).unwrap();
+                                    gauge
+                                });
+                                gauge.set(battery as f64);
+                                println!(
+                                    "Battery for device {}: {}%",
+                                    device_sensors.serial_number, battery
+                                );
                             }
 
-                            update_gauge!(
-                                data.temp,
-                                "airthings_temperature_celsius",
-                                "Temperature reading in degrees Celsius",
-                                "°C"
-                            );
-                            update_gauge!(
-                                data.humidity,
-                                "airthings_humidity_percent",
-                                "Relative humidity percentage",
-                                "%"
-                            );
-                            update_gauge!(
-                                data.co2,
-                                "airthings_co2_ppm",
-                                "CO2 concentration in parts per million",
-                                "ppm"
-                            );
-                            update_gauge!(
-                                data.voc,
-                                "airthings_voc_ppb",
-                                "Volatile Organic Compounds in parts per billion",
-                                "ppb"
-                            );
-                            update_gauge!(
-                                data.pressure,
-                                "airthings_pressure_hpa",
-                                "Atmospheric pressure in hectopascals",
-                                "hPa"
-                            );
-                            update_gauge!(
-                                data.radon_short_term_avg,
-                                "airthings_radon_bqm3",
-                                "Radon short term average in Bq/m³",
-                                "Bq/m³"
-                            );
-                            update_gauge!(
-                                data.pm1,
-                                "airthings_pm1_ugm3",
-                                "PM1 particulate matter in µg/m³",
-                                "µg/m³"
-                            );
-                            update_gauge!(
-                                data.pm25,
-                                "airthings_pm25_ugm3",
-                                "PM2.5 particulate matter in µg/m³",
-                                "µg/m³"
-                            );
-                            update_gauge!(
-                                data.battery,
-                                "airthings_battery_percent",
-                                "Battery level percentage",
-                                "%"
-                            );
-                        }
-                        Err(e) => {
-                            eprintln!("Failed to get samples for device {}: {}", device.id, e)
+                            // Process each sensor reading
+                            for sensor in device_sensors.sensors {
+                                let metric_name = format!("airthings_{}", sensor.sensor_type);
+                                let key =
+                                    format!("{}_{}", device_sensors.serial_number, metric_name);
+
+                                let gauge = gauges.entry(key).or_insert_with(|| {
+                                    let help = format!("{} in {}", sensor.sensor_type, sensor.unit);
+                                    let opts = Opts::new(&metric_name, &help)
+                                        .const_label("device_id", &device_sensors.serial_number)
+                                        .const_label("device_type", device_type);
+                                    let gauge = Gauge::with_opts(opts).unwrap();
+                                    state.registry.register(Box::new(gauge.clone())).unwrap();
+                                    gauge
+                                });
+
+                                gauge.set(sensor.value);
+                                println!(
+                                    "{} for device {}: {:.2} {}",
+                                    sensor.sensor_type,
+                                    device_sensors.serial_number,
+                                    sensor.value,
+                                    sensor.unit
+                                );
+                            }
                         }
                     }
+                    Err(e) => eprintln!("Failed to get sensors: {}", e),
                 }
             }
             Err(e) => eprintln!("Failed to get Airthings devices: {}", e),

--- a/src/main.rs
+++ b/src/main.rs
@@ -1,8 +1,12 @@
+mod airthings;
+
+use airthings::{AirthingsClient, AirthingsConfig};
 use axum::{extract::State, response::IntoResponse, routing::get, Router};
 use parking_lot::RwLock;
 use prometheus::{Encoder, Gauge, Opts, Registry, TextEncoder};
 use std::{
-    collections::HashMap, error::Error, fs, net::SocketAddr, path::Path, sync::Arc, time::Duration,
+    collections::HashMap, env, error::Error, fs, net::SocketAddr, path::Path, sync::Arc,
+    time::Duration,
 };
 use tokio::time;
 
@@ -10,6 +14,7 @@ use tokio::time;
 struct AppState {
     registry: Arc<Registry>,
     temperature_gauges: Arc<RwLock<HashMap<String, Gauge>>>,
+    airthings_gauges: Arc<RwLock<HashMap<String, Gauge>>>,
 }
 
 async fn metrics_handler(State(state): State<AppState>) -> impl IntoResponse {
@@ -74,6 +79,60 @@ async fn update_temperatures(devices_path: &Path, state: AppState) {
     }
 }
 
+async fn update_airthings(mut client: AirthingsClient, state: AppState) {
+    loop {
+        match client.get_devices().await {
+            Ok(devices) => {
+                for device in devices {
+                    match client.get_latest_samples(&device.id).await {
+                        Ok(samples) => {
+                            let mut gauges = state.airthings_gauges.write();
+                            let data = samples.data;
+
+                            // Helper macro to create/update gauge
+                            macro_rules! update_gauge {
+                                ($field:expr, $name:expr, $help:expr, $unit:expr) => {
+                                    if let Some(value) = $field {
+                                        let key = format!("{}_{}", device.id, $name);
+                                        let gauge = gauges.entry(key).or_insert_with(|| {
+                                            let opts = Opts::new($name, $help)
+                                                .const_label("device_id", &device.id)
+                                                .const_label("device_type", &device.device_type);
+                                            let gauge = Gauge::with_opts(opts).unwrap();
+                                            state.registry.register(Box::new(gauge.clone())).unwrap();
+                                            gauge
+                                        });
+                                        gauge.set(value);
+                                        println!(
+                                            "{} for device {}: {:.2} {}",
+                                            $name, device.id, value, $unit
+                                        );
+                                    }
+                                };
+                            }
+
+                            update_gauge!(data.temp, "airthings_temperature_celsius", "Temperature reading in degrees Celsius", "°C");
+                            update_gauge!(data.humidity, "airthings_humidity_percent", "Relative humidity percentage", "%");
+                            update_gauge!(data.co2, "airthings_co2_ppm", "CO2 concentration in parts per million", "ppm");
+                            update_gauge!(data.voc, "airthings_voc_ppb", "Volatile Organic Compounds in parts per billion", "ppb");
+                            update_gauge!(data.pressure, "airthings_pressure_hpa", "Atmospheric pressure in hectopascals", "hPa");
+                            update_gauge!(data.radon_short_term_avg, "airthings_radon_bqm3", "Radon short term average in Bq/m³", "Bq/m³");
+                            update_gauge!(data.pm1, "airthings_pm1_ugm3", "PM1 particulate matter in µg/m³", "µg/m³");
+                            update_gauge!(data.pm25, "airthings_pm25_ugm3", "PM2.5 particulate matter in µg/m³", "µg/m³");
+                            update_gauge!(data.battery, "airthings_battery_percent", "Battery level percentage", "%");
+                        }
+                        Err(e) => eprintln!("Failed to get samples for device {}: {}", device.id, e),
+                    }
+                }
+            }
+            Err(e) => eprintln!("Failed to get Airthings devices: {}", e),
+        }
+
+        // Update every 5 minutes (Airthings data is updated every 5 minutes)
+        time::sleep(Duration::from_secs(300)).await;
+    }
+}
+
 #[tokio::main]
 async fn main() -> Result<(), Box<dyn Error>> {
     println!("Starting temperature monitoring service");
@@ -81,13 +140,34 @@ async fn main() -> Result<(), Box<dyn Error>> {
     let state = AppState {
         registry: Arc::new(Registry::new()),
         temperature_gauges: Arc::new(RwLock::new(HashMap::new())),
+        airthings_gauges: Arc::new(RwLock::new(HashMap::new())),
     };
 
+    // Spawn w1-gpio temperature sensor monitoring
     let devices_path = "/sys/bus/w1/devices";
     let app_state = state.clone();
     tokio::spawn(async move {
         update_temperatures(Path::new(devices_path), app_state).await;
     });
+
+    // Spawn Airthings monitoring if credentials are provided
+    if let (Ok(client_id), Ok(client_secret)) = (
+        env::var("AIRTHINGS_CLIENT_ID"),
+        env::var("AIRTHINGS_CLIENT_SECRET"),
+    ) {
+        println!("Airthings credentials found, starting Airthings monitoring");
+        let config = AirthingsConfig {
+            client_id,
+            client_secret,
+        };
+        let client = AirthingsClient::new(config);
+        let app_state = state.clone();
+        tokio::spawn(async move {
+            update_airthings(client, app_state).await;
+        });
+    } else {
+        println!("Airthings credentials not found (AIRTHINGS_CLIENT_ID, AIRTHINGS_CLIENT_SECRET), skipping Airthings monitoring");
+    }
 
     let app = Router::new()
         .route("/metrics", get(metrics_handler))

--- a/src/main.rs
+++ b/src/main.rs
@@ -99,7 +99,10 @@ async fn update_airthings(mut client: AirthingsClient, state: AppState) {
                                                 .const_label("device_id", &device.id)
                                                 .const_label("device_type", &device.device_type);
                                             let gauge = Gauge::with_opts(opts).unwrap();
-                                            state.registry.register(Box::new(gauge.clone())).unwrap();
+                                            state
+                                                .registry
+                                                .register(Box::new(gauge.clone()))
+                                                .unwrap();
                                             gauge
                                         });
                                         gauge.set(value);
@@ -111,17 +114,64 @@ async fn update_airthings(mut client: AirthingsClient, state: AppState) {
                                 };
                             }
 
-                            update_gauge!(data.temp, "airthings_temperature_celsius", "Temperature reading in degrees Celsius", "°C");
-                            update_gauge!(data.humidity, "airthings_humidity_percent", "Relative humidity percentage", "%");
-                            update_gauge!(data.co2, "airthings_co2_ppm", "CO2 concentration in parts per million", "ppm");
-                            update_gauge!(data.voc, "airthings_voc_ppb", "Volatile Organic Compounds in parts per billion", "ppb");
-                            update_gauge!(data.pressure, "airthings_pressure_hpa", "Atmospheric pressure in hectopascals", "hPa");
-                            update_gauge!(data.radon_short_term_avg, "airthings_radon_bqm3", "Radon short term average in Bq/m³", "Bq/m³");
-                            update_gauge!(data.pm1, "airthings_pm1_ugm3", "PM1 particulate matter in µg/m³", "µg/m³");
-                            update_gauge!(data.pm25, "airthings_pm25_ugm3", "PM2.5 particulate matter in µg/m³", "µg/m³");
-                            update_gauge!(data.battery, "airthings_battery_percent", "Battery level percentage", "%");
+                            update_gauge!(
+                                data.temp,
+                                "airthings_temperature_celsius",
+                                "Temperature reading in degrees Celsius",
+                                "°C"
+                            );
+                            update_gauge!(
+                                data.humidity,
+                                "airthings_humidity_percent",
+                                "Relative humidity percentage",
+                                "%"
+                            );
+                            update_gauge!(
+                                data.co2,
+                                "airthings_co2_ppm",
+                                "CO2 concentration in parts per million",
+                                "ppm"
+                            );
+                            update_gauge!(
+                                data.voc,
+                                "airthings_voc_ppb",
+                                "Volatile Organic Compounds in parts per billion",
+                                "ppb"
+                            );
+                            update_gauge!(
+                                data.pressure,
+                                "airthings_pressure_hpa",
+                                "Atmospheric pressure in hectopascals",
+                                "hPa"
+                            );
+                            update_gauge!(
+                                data.radon_short_term_avg,
+                                "airthings_radon_bqm3",
+                                "Radon short term average in Bq/m³",
+                                "Bq/m³"
+                            );
+                            update_gauge!(
+                                data.pm1,
+                                "airthings_pm1_ugm3",
+                                "PM1 particulate matter in µg/m³",
+                                "µg/m³"
+                            );
+                            update_gauge!(
+                                data.pm25,
+                                "airthings_pm25_ugm3",
+                                "PM2.5 particulate matter in µg/m³",
+                                "µg/m³"
+                            );
+                            update_gauge!(
+                                data.battery,
+                                "airthings_battery_percent",
+                                "Battery level percentage",
+                                "%"
+                            );
                         }
-                        Err(e) => eprintln!("Failed to get samples for device {}: {}", device.id, e),
+                        Err(e) => {
+                            eprintln!("Failed to get samples for device {}: {}", device.id, e)
+                        }
                     }
                 }
             }


### PR DESCRIPTION
Integrated Airthings Consumer API to fetch air quality data alongside existing w1-gpio temperature sensors. The integration uses OAuth2 client credentials flow and exposes multiple metrics including:

- Temperature, humidity, CO2, VOC levels
- Atmospheric pressure
- Radon levels (short term average)
- Particulate matter (PM1, PM2.5)
- Battery levels

Configuration via environment variables (AIRTHINGS_CLIENT_ID and AIRTHINGS_CLIENT_SECRET). If credentials are not provided, the exporter gracefully skips Airthings monitoring.

Data is fetched every 5 minutes to align with Airthings API update frequency.